### PR TITLE
v1meta: return NoneDeref instead of None when a reference is broken

### DIFF
--- a/v1pysdk/none_deref.py
+++ b/v1pysdk/none_deref.py
@@ -1,0 +1,46 @@
+import unittest
+
+class NoneDeref(object):
+  def __getattr__(self, attr):
+    return self
+  
+  def __getstate__(self):
+    return None
+    
+  def __setstate__(self, state):
+    pass
+  
+  def __str__(self):
+    return "None"
+  
+  def __nonzero__(self):
+    return False
+  
+  def __bool__(self):
+    return False
+  
+class NoneDerefTest(unittest.TestCase):
+  def setUp(self):
+    self.object = NoneDeref()
+
+  def test_any_attribute_is_present_and_falsy(self):
+    self.assertFalse(self.object.foo)
+    self.assertFalse(self.object.bar)
+  
+  def test_object_is_falsy(self):
+    self.assertFalse(self.object)
+
+  def test_object_can_be_pickled(self):
+    import pickle
+    
+    s = pickle.dumps(self.object)
+    n = pickle.loads(s)
+    self.assertFalse(n)
+    self.assertFalse(self.object.foo)
+    self.assertFalse(self.object.bar)
+  
+  def test_object_converts_to_None_string(self):
+    self.assertEqual(str(self.object), "None")
+
+if __name__ == "__main__":
+  unittest.main()

--- a/v1pysdk/v1meta.py
+++ b/v1pysdk/v1meta.py
@@ -7,7 +7,7 @@ from client import *
 from base_asset import BaseAsset
 from cache_decorator import memoized
 from special_class_methods import special_classes
-
+from none_deref import NoneDeref
 
 class V1Meta(object):        
   def __init__(self, address='localhost', instance='VersionOne.Web', username='admin', password='admin'):
@@ -54,6 +54,8 @@ class V1Meta(object):
             v = self._v1_getattr(attr)
             if v:
               return self._v1_getattr(attr)[0]
+            else:
+              return NoneDeref()
           def setter(self, value, attr=attr):
             return self._v1_setattr(attr, [value])
           def deleter(self, attr=attr):


### PR DESCRIPTION
When a reference is broken, the asset object contains a None as a value
of the attribute. The issue with this is that call sites will have to
check unresolved references explicitly, e.g. if I wanted to write:

story_name = story.Scope.Name

I would have to check the Noneness of story.Scope before dereferencing
story.Scope.Name, like this:

if story.Scope:
    story_name = story.Scope.Name
else:
    story_name = None

This patch changes that, if a reference would become None, it results in
an object that behaves like a None but call-sites can continue to dereference
attributes within that.

Signed-off-by: Balazs Scheidler bazsi@balabit.hu
