### PR TITLE
Fix updating of single relation

### DIFF
--- a/v1pysdk/client.py
+++ b/v1pysdk/client.py
@@ -116,6 +116,7 @@ class V1Server(object):
     exception, body = self.fetch(path, query=query, postdata=postdata)
     if exception:
       logging.warn("{0} during {1}".format(exception, msg))
+      logging.warn(postdata)
     document = ElementTree.fromstring(body)
     if exception:
       exception.xmldoc = document

--- a/v1pysdk/v1meta.py
+++ b/v1pysdk/v1meta.py
@@ -57,7 +57,7 @@ class V1Meta(object):
             else:
               return NoneDeref()
           def setter(self, value, attr=attr):
-            return self._v1_setattr(attr, [value])
+            return self._v1_setattr(attr, value)
           def deleter(self, attr=attr):
             raise NotImplementedError
       else:
@@ -95,14 +95,18 @@ class V1Meta(object):
   def generate_update_doc(self, newdata):
     update_doc = Element('Asset')
     for attrname, newvalue in newdata.items():
-      if isinstance(newvalue, BaseAsset):
+      if newvalue is None: # single relation was removed
+        node = Element('Relation')
+        node.set('name', attrname)
+        node.set('act', 'set')
+      elif isinstance(newvalue, BaseAsset): # single relation was changed
         node = Element('Relation')
         node.set('name', attrname)
         node.set('act', 'set')
         ra = Element('Asset')
         ra.set('idref', newvalue.idref)
         node.append(ra)
-      elif isinstance(newvalue, list):
+      elif isinstance(newvalue, list): # multi relation was changed
         node = Element('Relation')
         node.set('name', attrname)
         for item in newvalue:
@@ -110,7 +114,7 @@ class V1Meta(object):
           child.set('idref', item.idref)
           child.set('act', 'add')
           node.append(child)
-      else:
+      else: # Not a relation
         node = Element('Attribute')
         node.set('name', attrname)
         node.set('act', 'set')


### PR DESCRIPTION
This is to fix a problem I had while trying to update the status of a task.  It was generating XML for the multi-relation when it should have been generating it for a single-relation.  This change makes single relations just a pointer to a `BaseAsset`, instead of a pointer to a list containing a single `BaseAsset`.  That allows discrimination between single and multi relations.  Also, setting the pointer to `None` will generate the XML code to remove the relation.

This pull request also logs the posted xml data if an error occurred, which I found valuable during debugging.

Note, I also found a bug in the multi-relation part of this function, where it doesn't detect the removal of a relation.  This prevents unassigning a member from a task, for example.  I am considering possible solutions, and will submit that fix in a separate pull request.
