### PR TITLE
Properly split attribute strings, even if they have sub attributes

### DIFF
--- a/v1pysdk/query.py
+++ b/v1pysdk/query.py
@@ -1,6 +1,35 @@
 
 from urllib import urlencode
 
+
+def attrstring_splitter(attrstring):
+    """
+    properly split apart attribute strings, even when they have sub-attributes declated between [].
+    :param attrstring:
+    :return: dict containing the elements of the top level attribute string.
+    Sub-attribute strings between '[]'s are appended to their parent, without processing, even if they contain '.'
+    """
+    ret = []
+    spl = attrstring.split('[')
+    while len(spl) > 1:
+        prefix = spl[0].split('.')
+        if len(prefix) > 1:
+            ret += prefix[(len(prefix) - 2):]
+            lastleaf = prefix[len(prefix)-1]
+        else:
+            lastleaf = prefix[0]
+        subp, postfix = spl[1].split(']')
+        ret.append("%s[%s]" % (lastleaf, subp))
+        spl.pop(0)
+        if postfix != '' and postfix[0] == '.':
+            postfix = postfix[1:]
+        spl[0] = postfix
+    if len(spl) == 1 and spl[0] != '':
+        ret += spl[0].split('.')
+
+    return ret
+
+
 class V1Query(object):
   """A fluent query object. Use .select() and .where() to add items to the
   select list and the query criteria, then iterate over the object to execute
@@ -72,7 +101,7 @@ class V1Query(object):
     without further network traffic"""
     
     for sel in args:
-      parts = sel.split('.')
+      parts = attrstring_splitter(sel)
       for i in range(1, len(parts)):
         self.sel_list.append('.'.join(parts[:i]))
       self.sel_list.append(sel)

--- a/v1pysdk/v1meta.py
+++ b/v1pysdk/v1meta.py
@@ -8,6 +8,7 @@ from base_asset import BaseAsset
 from cache_decorator import memoized
 from special_class_methods import special_classes
 from none_deref import NoneDeref
+from query import attrstring_splitter
 
 class V1Meta(object):        
   def __init__(self, *args, **kw):
@@ -165,7 +166,7 @@ class V1Meta(object):
       self.add_attribute_to_output(output, key, values)
 
   def unpack_asset_relations(self, output, xml):
-  
+
     # we sort relations in order to insert the shortest ones first, so that
     # containing relations are added before leaf ones.
     for relation in sorted(xml.findall('Relation'), key=lambda x: x.get('name')):
@@ -204,15 +205,16 @@ class V1Meta(object):
       output[relation] = values[0]
       
   def is_attribute_qualified(self, relation):
-    return relation.find('.') >= 0
+    parts = attrstring_splitter(relation)
+    return len(parts) > 1
   
   def split_relation_to_container_and_leaf(self, relation):
-    parts = relation.split('.')
-    return ('.'.join(relation.split('.')[:-1]), parts[-1])
+    parts = attrstring_splitter(relation)
+    return ('.'.join(parts[:-1]), parts[-1])
   
   def get_related_assets(self, output, relation):
     if self.is_attribute_qualified(relation):
-      parts = relation.split('.')
+      parts = attrstring_splitter(relation)
 
       assets = output[parts[0]]
 


### PR DESCRIPTION
The SDK improperly procesess both search strings and server
responses for said search strings, if the original search string
contains filters between '[]' and said filter contain a '.'.

Example:
Original search string: History[Status.Name='Done']
This will be processed as ["History[Status", "Name='Done']"]
