### PR TITLE
Prevent querying for double-underscored properties accessed by Python internals.

### DIFF
--- a/v1pysdk/query.py
+++ b/v1pysdk/query.py
@@ -105,8 +105,17 @@ class V1Query(object):
       found_asset.pending(updatelist)
       
   def __getattr__(self, attrname):
-    "return a sequence of the attribute from all matched results "
-    if attrname not in self.sel_list:
+    """ Return a sequence of the attribute from all matched results
+
+    .. note::
+
+       Also checks that the selected attribute does not begin with a
+       double-underscore to prevent firing off queries when python
+       dunder properties are checked (like `__length_hint__` via
+       `PEP0424 <http://legacy.python.org/dev/peps/pep-0424/>`_).
+
+    """
+    if attrname not in self.sel_list and not attrname.startswith('__'):
       self.select(attrname)
     return (getattr(i, attrname) for i in self)
 


### PR DESCRIPTION
Python allows classes to define a variety of double-underscore-prefixed names (colloquially referred to as 'dunder' methods) to change the behavior of a class.  One such of these methods, [named `__length_hint__`](http://legacy.python.org/dev/peps/pep-0424/), is accessed in Python 2.6 when performing a select.

This patch fixes this glitch for Python 2.6, and prevents other magic method lookups from triggering similar queries.  Please note that the fact that this will not prevent the `AttributeError` from being raised is intentional -- the raising of that exception is how Python internals are able to tell whether that method is defined.

Cheers, and let me know if you have any questions!