### PR TITLE
get_xml 5XX error handling and debugging for net traffic

### DIFF
--- a/v1pysdk/query.py
+++ b/v1pysdk/query.py
@@ -74,7 +74,9 @@ class V1Query(object):
     for sel in args:
       parts = split_attribute(sel)
       for i in range(1, len(parts)):
-        self.sel_list.append('.'.join(parts[:i]))
+        pname = '.'.join(parts[:i])
+        if pname not in self.sel_list:
+          self.sel_list.append(pname)
       self.sel_list.append(sel)
     return self
     


### PR DESCRIPTION
Hi,

Due to an error with our V1 server, I ran into the problem that get_xml() trying to parse the HTML page returned by the server when V1 caused an 500 Internal Error, which led to another 
exception in ElementTree. The first patch fixes this, by handling 5XX HTTP responses separately.

The second patch adds debug logging to the fetch method, so we can see the low level conversation between the server and the client, if logging module's loglevel is high enough.