### PR TITLE
v1meta: Fix UnicodeEncodeError when using utf-8 in newvalue

### DIFF
--- a/v1pysdk/v1meta.py
+++ b/v1pysdk/v1meta.py
@@ -119,8 +119,11 @@ class V1Meta(object):
         node = Element('Attribute')
         node.set('name', attrname)
         node.set('act', 'set')
-        node.text = str(newvalue)
-      update_doc.append(node)
+        if isinstance(newvalue, unicode) != True:
+            node.text = str(newvalue).decode('utf-8')
+        else:
+            node.text = newvalue
+       update_doc.append(node)
     return update_doc
     
   def create_asset(self, asset_type_name, newdata):


### PR DESCRIPTION
VersionOne API supports utf-8, but generate_update_doc method could not handle unicode object correctly.
For example, if I'd like to update asset with Japanese words, generate_update_doc method raises UnicodeEncodeError.
This commit fixed that issue to use decode method instead of str.