### PR TITLE
History attribute now returns correct versions of the core object.

### DIFF
--- a/v1pysdk/base_asset.py
+++ b/v1pysdk/base_asset.py
@@ -54,14 +54,15 @@ class BaseAsset(object):
   "that knows how to be iterated over, so we can say list(v1.Story)"
   __metaclass__ = IterableType
               
-  def __new__(Class, oid):
+  def __new__(Class, oid, moment=None):
     "Tries to get an instance out of the cache first, otherwise creates one"
-    cache_key = (Class._v1_asset_type_name, int(oid))
+    cache_key = (Class._v1_asset_type_name, oid, moment)
     cache = Class._v1_v1meta.global_cache
     if cache.has_key(cache_key):
       self = cache[cache_key]
     else:
-      self = object.__new__(Class)
+      self = object.__new__(Class)  
+      self._v1_moment = moment
       self._v1_oid = oid
       self._v1_new_data = {}
       self._v1_current_data = {}
@@ -86,7 +87,10 @@ class BaseAsset(object):
     
   @property
   def reprref(self):
-      return "{0}({1})".format(self._v1_asset_type_name, self._v1_oid)
+      if self._v1_moment:
+        return "{0}({1}:{2})".format(self._v1_asset_type_name, self._v1_oid, self._v1_moment)
+      else:
+        return "{0}({1})".format(self._v1_asset_type_name, self._v1_oid)
     
   @property
   def url(self):
@@ -176,11 +180,11 @@ class BaseAsset(object):
     
   def _v1_refresh(self):
     'Syncs the objects from current server data'
-    self._v1_current_data = self._v1_v1meta.read_asset(self._v1_asset_type_name, self._v1_oid)
+    self._v1_current_data = self._v1_v1meta.read_asset(self._v1_asset_type_name, self._v1_oid, self._v1_moment)
     self._v1_needs_refresh = False
     
   def _v1_get_single_attr(self, attr):
-    return self._v1_v1meta.get_attr(self._v1_asset_type_name, self._v1_oid, attr)
+    return self._v1_v1meta.get_attr(self._v1_asset_type_name, self._v1_oid, attr, self._v1_moment)
     
   def _v1_execute_operation(self, opname):
     result = self._v1_v1meta.execute_operation(self._v1_asset_type_name, self._v1_oid, opname)

--- a/v1pysdk/client.py
+++ b/v1pysdk/client.py
@@ -167,8 +167,8 @@ class V1Server(object):
         raise V1Error(exception)
     return document
    
-  def get_asset_xml(self, asset_type_name, oid):
-    path = '/rest-1.v1/Data/{0}/{1}'.format(asset_type_name, oid)
+  def get_asset_xml(self, asset_type_name, oid, moment=None):
+    path = '/rest-1.v1/Data/{0}/{1}/{2}'.format(asset_type_name, oid, moment) if moment else '/rest-1.v1/Data/{0}/{1}'.format(asset_type_name, oid)
     return self.get_xml(path)
     
   def get_query_xml(self, asset_type_name, where=None, sel=None):
@@ -189,8 +189,8 @@ class V1Server(object):
     query = {'op': opname}
     return self.get_xml(path, query=query, postdata={})
     
-  def get_attr(self, asset_type_name, oid, attrname):
-    path = '/rest-1.v1/Data/{0}/{1}/{2}'.format(asset_type_name, oid, attrname)
+  def get_attr(self, asset_type_name, oid, attrname, moment=None):
+    path = '/rest-1.v1/Data/{0}/{1}/{3}/{2}'.format(asset_type_name, oid, attrname, moment) if moment else '/rest-1.v1/Data/{0}/{1}/{2}'.format(asset_type_name, oid, attrname)
     return self.get_xml(path)
   
   def create_asset(self, asset_type_name, xmldata, context_oid=''):

--- a/v1pysdk/v1meta.py
+++ b/v1pysdk/v1meta.py
@@ -136,8 +136,8 @@ class V1Meta(object):
   def execute_operation(self, asset_type_name, oid, opname):
     return self.server.execute_operation(asset_type_name, oid, opname)
     
-  def get_attr(self, asset_type_name, oid, attrname):
-    xml = self.server.get_attr(asset_type_name, oid, attrname)
+  def get_attr(self, asset_type_name, oid, attrname, moment=None):
+    xml = self.server.get_attr(asset_type_name, oid, attrname, moment)
     dummy_asset = ElementTree.Element('Asset')
     dummy_asset.append(xml)
     return self.unpack_asset(dummy_asset)[attrname]
@@ -145,8 +145,8 @@ class V1Meta(object):
   def query(self, asset_type_name, wherestring, selstring):
     return self.server.get_query_xml(asset_type_name, wherestring, selstring)
     
-  def read_asset(self, asset_type_name, asset_oid):
-    xml = self.server.get_asset_xml(asset_type_name, asset_oid)
+  def read_asset(self, asset_type_name, asset_oid, moment=None):
+    xml = self.server.get_asset_xml(asset_type_name, asset_oid, moment)
     return self.unpack_asset(xml)
     
   def unpack_asset(self, xml):
@@ -237,9 +237,10 @@ class V1Meta(object):
       return None
   
   def asset_from_oid(self, oidtoken):
-    asset_type, asset_id = oidtoken.split(':')[:2]
+    oid_parts = oidtoken.split(":")
+    (asset_type, asset_id, moment) = oid_parts if len(oid_parts)>2 else (oid_parts[0], oid_parts[1], None)
     AssetClass = self.asset_class(asset_type)
-    instance = AssetClass(asset_id)
+    instance = AssetClass(asset_id, moment)
     return instance
     
   def set_attachment_blob(self, attachment, data=None):


### PR DESCRIPTION
This pull request fixes the 'History' attribute.  Instances of the core object in the History list were always the current version instead of the version at that point in time in history.    This code modifies the history attribute to use moments so that instances show the correct values at that point in time.