### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ setup(
     ],  
   
   install_requires = [
-    'elementtree',
     'testtools',
     'iso8601',
     'python-ntlm',


### PR DESCRIPTION
elementtree should not be a requirement since it belongs to xml.etree package module and it's part of the standard library.

Otherwise when trying to install using pip or python setup.py it will fail trying to install the dependency.
