### PR TITLE
Fix broken indentation

### DIFF
--- a/v1pysdk/v1meta.py
+++ b/v1pysdk/v1meta.py
@@ -123,7 +123,7 @@ class V1Meta(object):
             node.text = str(newvalue).decode('utf-8')
         else:
             node.text = newvalue
-       update_doc.append(node)
+      update_doc.append(node)
     return update_doc
     
   def create_asset(self, asset_type_name, newdata):


### PR DESCRIPTION
In call to update_doc.append

Error while installing:
```
Sorry: IndentationError: unindent does not match any outer indentation level (v1meta.py, line 126)
```
During runtime:
```
...
Traceback (most recent call last):                              
  ...
, in <module>                                                   
    from v1pysdk import V1Meta                                  
  File "build\bdist.win32\egg\v1pysdk\__init__.py", line 10, in 
<module>                                                        
  File "C:\Python27\lib\site-packages\v1pysdk-0.4-py2.7.egg\v1py
sdk\v1meta.py", line 126                                        
    update_doc.append(node)                                     
                          ^                                     
IndentationError: unindent does not match any outer indentation 
level                                                           
Done                                                            
```
